### PR TITLE
Rename users to snmp_users for compatibility with node-red 4.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ snmpTrapListener(null, {
     snmpV1: true,
     snmpV2: true,
     snmpV3: true,
-    communities: [
+    snmp_communities: [
         {
             community: "tip",
         },
@@ -18,7 +18,7 @@ snmpTrapListener(null, {
             community: "top",
         },
     ],
-    users: [
+    snmp_users: [
         {
             name: "titi",
             authProtocol: "none",
@@ -43,4 +43,5 @@ snmpTrapListener(null, {
     ],
     ipfilter: "",
     ipmask: "",
+    schema: 2,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-red-contrib-snmp-trap-listener",
-	"version": "2.3.0",
+	"version": "2.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-snmp-trap-listener",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "private": false,
     "description": "Node-RED node that receives snmp traps.",
     "main": "index.js",

--- a/snmp-trap-listener.html
+++ b/snmp-trap-listener.html
@@ -11,8 +11,8 @@
             snmpV1: { value: true },
             snmpV2: { value: true },
             snmpV3: { value: true },
-            communities: { value: [{ community: "" }] },
-            users: {
+            snmp_communities: { value: [{ community: "" }] },
+            snmp_users: {
                 value: [
                     {
                         name: "",
@@ -25,6 +25,7 @@
             },
             ipfilter: { value: "" },
             ipmask: { value: "" },
+            schema: { value: undefined },
         },
         inputs: 0,
         outputs: 1,
@@ -34,6 +35,30 @@
         },
         oneditprepare: function () {
             let node = this;
+
+            // If an existing node has no schema set yet, it signifies to us that newer node-red versions (>= 4.1.0) won't allow us to directly read key portions of the existing node config, which will lead to blank SNMPv3 fields in the editor.
+            // Saving it then erases the SNMPv3 users that were in the old, presumably working config.
+            // We can work around the restriction placed on the old 'users' property by adding a temporary endpoint that allows us to fetch it directly from the flow.
+            // See https://github.com/ItsEcholot/node-red-contrib-snmp-trap-listener/issues/25 for details.
+            if (node._config && (!node.schema || node.schema < 2)) {
+                $.ajax({
+                    url: "snmp-trap-listener/migration/" + node.id,
+                    type: "GET",
+                    async: false, // this needs to block, as the missing data we're fetching is *normally* accessible immediately
+                    success: function (data) {
+                        node.snmp_users = data.snmp_users;
+                        node.snmp_communities = data.snmp_communities;
+
+                        RED.nodes.dirty(true);
+                        RED.notify("snmp-trap-listener node has been automatically updated to the latest schema; deploy to save changes.");
+                    },
+                    error: function(jqXHR, textStatus, errorThrown) {
+                        if (jqXHR.status !== 404) {
+                            console.warn("Failed to fetch migration data for snmp-trap-listener: ", textStatus);
+                        }
+                    }
+                });
+            }
 
             let tabs = RED.tabs.create({
                 id: "node-input-snmp-trap-tabs",
@@ -247,8 +272,8 @@
                 );
             });
 
-            for (let i = 0; i < this.communities.length; i++) {
-                let community = this.communities[i];
+            for (let i = 0; i < this.snmp_communities.length; i++) {
+                let community = this.snmp_communities[i];
                 generateCommunity(i + 1, community);
             }
 
@@ -557,8 +582,8 @@
                 );
             });
 
-            for (let i = 0; i < this.users.length; i++) {
-                let user = this.users[i];
+            for (let i = 0; i < this.snmp_users.length; i++) {
+                let user = this.snmp_users[i];
                 generateUser(i + 1, user);
             }
 
@@ -572,24 +597,24 @@
             let node = this;
             node.formValue = {};
 
-            let communities = $("#node-input-community-container").children();
-            node.communities = [];
-            communities.each(function (i) {
+            let snmp_communities = $("#node-input-community-container").children();
+            node.snmp_communities = [];
+            snmp_communities.each(function (i) {
                 let community = $(this);
-                // communities: {value:[{community:""}]},
+                // snmp_communities: {value:[{community:""}]},
                 let o = {
                     community: community
                         .find(".node-input-community-value")
                         .val(),
                 };
-                node.communities.push(o);
+                node.snmp_communities.push(o);
             });
 
-            let users = $("#node-input-user-container").children();
-            node.users = [];
-            users.each(function (i) {
+            let snmp_users = $("#node-input-user-container").children();
+            node.snmp_users = [];
+            snmp_users.each(function (i) {
                 let user = $(this);
-                // users: {value:[{name:"", authProtocol:"", authKey:"", privProtocol:"", privKey:""}]},
+                // snmp_users: {value:[{name:"", authProtocol:"", authKey:"", privProtocol:"", privKey:""}]},
                 let o = {
                     name: user.find(".node-input-user-name").val(),
                     authProtocol: user
@@ -601,8 +626,10 @@
                         .val(),
                     privKey: user.find(".node-input-user-privKey").val(),
                 };
-                node.users.push(o);
+                node.snmp_users.push(o);
             });
+
+            node.schema = 2;
         },
     });
 </script>

--- a/snmp-trap-listener.js
+++ b/snmp-trap-listener.js
@@ -73,6 +73,34 @@ module.exports = (RED, debugSettings) => {
         return false;
     }
 
+    // Ensure the migration endpoint is registered only once, even if there are multiple nodes.
+    var migrationEndpointRegistered = false;
+    function registerMigrationEndpoint(n) {
+        if (migrationEndpointRegistered) {
+            return;
+        }
+
+        migrationEndpointRegistered = true;
+
+        n.log("Registering migration endpoint");
+
+        RED.httpAdmin.get(
+            "/snmp-trap-listener/migration/:id",
+            RED.auth.needsPermission("snmp-trap-listener.read"),
+            function (req, res) {
+                var node = RED.nodes.getNode(req.params.id);
+                if (node && node.migrate_snmp) {
+                    res.json({
+                        snmp_users: node.migrate_snmp_users,
+                        snmp_communities: node.migrate_snmp_communities
+                    });
+                } else {
+                    res.status(404).send();
+                }
+            },
+        );
+    }
+
     function snmpTrapListener(config) {
         if (RED) {
             RED.nodes.createNode(this, config);
@@ -117,6 +145,29 @@ module.exports = (RED, debugSettings) => {
             };
         }
 
+        // node-red >= 4.1.0 restricts the use of the 'node.users' property, so it has been moved to snmp_users
+        if (!config.schema || config.schema < 2) {
+            if (config.users && !config.snmp_users)
+                config.snmp_users = config.users;
+
+            if (config.communities && !config.snmp_communities)
+                config.snmp_communities = config.communities;
+
+            delete config.users;
+            delete config.communities;
+
+            if (RED) {
+                node.migrate_snmp = true;
+                node.migrate_snmp_users = config.snmp_users;
+                node.migrate_snmp_communities = config.snmp_communities;
+
+                node.warn("Saved configuration for this node is using obsolete field names and will be migrated to the new schema on next redeploy");
+
+                // Set up an admin HTTP endpoint that allows the editor to fetch these now-restricted properties
+                registerMigrationEndpoint(node);
+            }
+        }
+
         // Add a timeout to reset the status to green after x time (ms)
         let timeoutStatus;
 
@@ -141,7 +192,7 @@ module.exports = (RED, debugSettings) => {
         // Default options
         var options = {
             port: parseInt(config.port, 10),
-            disableAuthorization: !config.communities && !config.users,
+            disableAuthorization: !config.snmp_communities && !config.snmp_users,
             engineID: "8000B98380XXXXXXXXXXXX", // where the X's are random hex digits
             transport: "udp4",
         };
@@ -315,10 +366,10 @@ module.exports = (RED, debugSettings) => {
         node.log("Listening for traps on port: " + config.port);
         let authorizer = node.receiver.getAuthorizer();
         if (config.snmpV1 || config.snmpV2) {
-            let communities = config.communities || [];
+            let snmp_communities = config.snmp_communities || [];
 
-            communities.forEach((communitie) => {
-                let community = communitie.community;
+            snmp_communities.forEach((snmp_community) => {
+                let community = snmp_community.community;
                 if (community !== "") {
                     node.log("Adding Community: " + community);
                     authorizer.addCommunity(community);
@@ -328,8 +379,8 @@ module.exports = (RED, debugSettings) => {
             });
         }
         if (config.snmpV3) {
-            let users = config.users || [];
-            users.forEach((user) => {
+            let snmp_users = config.snmp_users || [];
+            snmp_users.forEach((user) => {
                 if (
                     user.name !== "" &&
                     (user.authProtocol === "none" || user.authKey !== "") &&


### PR DESCRIPTION
'users' became a restricted keyword per https://github.com/node-red/node-red/commit/26e58a53b720f741ca950e577dfbaf3cbe0d39a5 which causes an error when attempting to edit/save settings in node-red 4.1.0 and higher.

As a workaround, switch users to snmp_users, and switch communities to snmp_communities for consistency.

Since this restriction makes editing old nodes impossible due to the inability to fetch the saved config, a RED.httpAdmin.get() endpoint is conditionally started that allows the editor to fetch the missing part of the old config out of band.

A new hidden config variable 'schema' is added. The absence of this in the existing config is used to determine whether or not the migration endpoint should be fetched. The updated config schema will be 2, as the first was implicitly 1.

Also, bump module version to 2.5.0.

Fixes #25